### PR TITLE
fix README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-testdata/*
-!testdata/.gitkeep
+.DS_Store
+testdata/
 *.mpg
 *.m2t
 *.m2ts

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ $ ./mpeg-ts-analyzer sample_data/sample.ts
 Input file:  sample_data/sample.ts
 Detected PAT: PMT pid = 0x1000
 Detected PMT
-PMT : Program Info : elementary_PID	: 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
-PMT : Program Info : elementary_PID	: 0x101, stream_type : 0x03 (11172 audio)
+PMT : Program Info : elementary_PID     : 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
+PMT : Program Info : elementary_PID     : 0x101, stream_type : 0x03 (11172 audio)
 ```
 
 ## Dump TS header
@@ -53,33 +53,33 @@ Input file:  sample_data/sample.ts
 ===============================================================
  TS Header
 ===============================================================
-transport_error_indicator	: 0
-payload_unit_start_indicator	: 1
-transport_priority		: 0
-pid				: 0x0
-transport_scrambling_control	: 0
-adaptation_field_control	: 1
-continuity_counter		: 0
+transport_error_indicator       : 0
+payload_unit_start_indicator    : 1
+transport_priority              : 0
+pid                             : 0x0
+transport_scrambling_control    : 0
+adaptation_field_control        : 1
+continuity_counter              : 0
 ===============================================================
  TS Header
 ===============================================================
-transport_error_indicator	: 0
-payload_unit_start_indicator	: 1
-transport_priority		: 0
-pid				: 0x1000
-transport_scrambling_control	: 0
-adaptation_field_control	: 1
-continuity_counter		: 0
+transport_error_indicator       : 0
+payload_unit_start_indicator    : 1
+transport_priority              : 0
+pid                             : 0x1000
+transport_scrambling_control    : 0
+adaptation_field_control        : 1
+continuity_counter              : 0
 ===============================================================
  TS Header
 ===============================================================
-transport_error_indicator	: 0
-payload_unit_start_indicator	: 1
-transport_priority		: 0
-pid				: 0x100
-transport_scrambling_control	: 0
-adaptation_field_control	: 3
-continuity_counter		: 0
+transport_error_indicator       : 0
+payload_unit_start_indicator    : 1
+transport_priority              : 0
+pid                             : 0x100
+transport_scrambling_control    : 0
+adaptation_field_control        : 3
+continuity_counter              : 0
 ```
 
 ## Dump PSI
@@ -92,35 +92,35 @@ Detected PAT: PMT pid = 0x1000
 ===========================================
  PAT
 ===========================================
-PAT : table_id			: 0x0
-PAT : section_syntax_indicator	: 1
-PAT : section_length		: 13
-PAT : transport_stream_id	: 1
-PAT : version_number		: 0
-PAT : current_next_indicator	: 1
-PAT : section_number		: 0
-PAT : last_section_number	: 0
-PAT : program_number		: 1
-PAT : program_map_PID		: 0x1000
-PAT : CRC_32			: 2ab104b2
+PAT : table_id                          : 0x0
+PAT : section_syntax_indicator          : 1
+PAT : section_length                    : 13
+PAT : transport_stream_id               : 1
+PAT : version_number                    : 0
+PAT : current_next_indicator            : 1
+PAT : section_number                    : 0
+PAT : last_section_number               : 0
+PAT : program_number                    : 1
+PAT : program_map_PID                   : 0x1000
+PAT : CRC_32                            : 2ab104b2
 Detected PMT
 
 ===========================================
  PMT
 ===========================================
-PMT : table_id			: 0x2
-PMT : section_syntax_indicator	: 1
-PMT : section_length		: 23
-PMT : program_number		: 1
-PMT : version_number		: 0
-PMT : current_next_indicator	: 1
-PMT : section_number		: 0
-PMT : last_section_number	: 0
-PMT : PCR_PID			: 0x100
-PMT : program_info_length	: 0
-PMT : Program Info : elementary_PID	: 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
-PMT : Program Info : elementary_PID	: 0x101, stream_type : 0x03 (11172 audio)
-PMT : CRC_32			: f64a0355
+PMT : table_id                          : 0x2
+PMT : section_syntax_indicator          : 1
+PMT : section_length                    : 23
+PMT : program_number                    : 1
+PMT : version_number                    : 0
+PMT : current_next_indicator            : 1
+PMT : section_number                    : 0
+PMT : last_section_number               : 0
+PMT : PCR_PID                           : 0x100
+PMT : program_info_length               : 0
+PMT : Program Info : elementary_PID     : 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
+PMT : Program Info : elementary_PID     : 0x101, stream_type : 0x03 (11172 audio)
+PMT : CRC_32                            : f64a0355
 ```
 
 ## Dump timestamp
@@ -130,8 +130,8 @@ $ ./mpeg-ts-analyzer sample_data/sample.ts --dump-timestamp
 Input file:  sample_data/sample.ts
 Detected PAT: PMT pid = 0x1000
 Detected PMT
-PMT : Program Info : elementary_PID	: 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
-PMT : Program Info : elementary_PID	: 0x101, stream_type : 0x03 (11172 audio)
+PMT : Program Info : elementary_PID     : 0x100, stream_type : 0x02 (13818-2 video or 11172-2 constrained parameter video stream)
+PMT : Program Info : elementary_PID     : 0x101, stream_type : 0x03 (11172 audio)
 0x000034e0 PCR: 0x018344a0[00940.000000ms]
 0x000034e0 DTS: 0x00024090[01640.000000ms] (pid:0x100) (delay:700.000000ms)
 0x0000359c PTS: 0x00023a3a[01621.977778ms] (pid:0x101) (delay:668.922222ms)


### PR DESCRIPTION
- Replace tabs with spaces in README code blocks for consistent rendering across editors and GitHub
- Simplify testdata/ gitignore to exclude the entire directory instead of using .gitkeep workaround