### PR TITLE
add VERSION file, install targets, and Homebrew tap support

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,3 +26,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,17 @@ archives:
       - goos: windows
         format: zip
 
+brews:
+  - repository:
+      owner: small-teton
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/small-teton/mpeg-ts-analyzer"
+    description: "An analyzer for MPEG-2 Transport Stream (ISO/IEC 13818-1)"
+    license: "Apache-2.0"
+    install: |
+      bin.install "mpeg-ts-analyzer"
+
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ ffmpeg -f lavfi -i "color=c=red:s=320x240:d=2,format=yuv420p" \
 
 # Install
 
-Pre-built binaries are available on the [Releases](https://github.com/small-teton/mpeg-ts-analyzer/releases) page. No additional tools required.
+## Homebrew (macOS / Linux)
+
+```bash
+brew install small-teton/tap/mpeg-ts-analyzer
+```
+
+## Pre-built binaries
+
+Download from the [Releases](https://github.com/small-teton/mpeg-ts-analyzer/releases) page. No additional tools required.
+
+## Go install
 
 If you have a [Go](https://go.dev/dl/) environment (1.21+):
 


### PR DESCRIPTION
## Summary
- Add `VERSION` file and `install`/`uninstall` targets to Makefile
- Add Homebrew tap support via GoReleaser (`brews` section)
- Update README with Homebrew, pre-built binary, and `go install` sections

## Pre-requisites before tagging v1.2.0
- [ ] Create `small-teton/homebrew-tap` repository on GitHub
- [ ] Add `HOMEBREW_TAP_GITHUB_TOKEN` secret to this repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)