### PR TITLE
add release workflow and make release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read VERSION
+        id: version
+        run: echo "version=$(cat VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Check tag does not exist
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ steps.version.outputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test coverage clean setup install uninstall
+.PHONY: build test coverage clean setup install uninstall release
 
 build:
 	go build -v ./...
@@ -23,6 +23,12 @@ install:
 
 uninstall:
 	rm -f $(shell go env GOPATH)/bin/mpeg-ts-analyzer
+
+release:
+	@VERSION=$$(cat VERSION | tr -d '[:space:]') && \
+	echo "Releasing v$$VERSION..." && \
+	git tag "v$$VERSION" && \
+	git push origin "v$$VERSION"
 
 setup:
 	git config core.hooksPath .githooks


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` workflow to trigger releases from GitHub Actions UI
  - Reads version from `VERSION` file
  - Checks that the tag doesn't already exist
  - Creates and pushes the tag, which triggers the existing goreleaser workflow
- Add `make release` target for local release via CLI

## Usage

**GitHub UI:** Actions → Release → Run workflow

**CLI:** `make release`

Both read `VERSION` file and create/push the corresponding git tag. The existing goreleaser workflow handles the rest (build, changelog, GitHub Release, Homebrew Formula update, deb/rpm/apk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)